### PR TITLE
add payload handler logic to cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,69 @@
 [![GitHub - Deployment](https://github.com/geo-martino/aiorequestful/actions/workflows/deploy.yml/badge.svg?event=release)](https://github.com/geo-martino/aiorequestful/actions/workflows/deploy.yml)
 [![GitHub - Documentation](https://github.com/geo-martino/aiorequestful/actions/workflows/docs_publish.yml/badge.svg)](https://github.com/geo-martino/aiorequestful/actions/workflows/docs_publish.yml)
 
-### Asynchronous RESTful API requests framework for asyncio and Python
+### An Asynchronous HTTP and RESTful API requests framework for asyncio and Python
 
 ## Contents
+* [Getting Started](#quick-guides)
+* [Currently Supported](#currently-supported)
+* [Release History](#release-history)
+* [Contributing](#contributing)
+* [Motivation & Aims](#aims)
+* [Author Notes](#notes)
+
+> [!NOTE]  
+> This readme provides a brief overview of the program. 
+> [Read the docs](https://geo-martino.github.io/aiorequestful/) for full reference documentation.
+
+
+## Installation
+Install through pip using one of the following commands:
+
+```bash
+pip install aiorequestful
+```
+```bash
+python -m pip install aiorequestful
+```
+
+There are optional dependencies that you may install for optional functionality. 
+For the current list of optional dependency groups, [read the docs](https://geo-martino.github.io/aiorequestful/howto.install.html)
+
+
+## Getting Started
+
+These quick guides will help you get set up and going with aiorequestful in just a few minutes.
+For more detailed guides, check out the [documentation](https://geo-martino.github.io/aiorequestful/).
+
+***Coming soon...***
+
+
+## Currently Supported
+
+- **Cache Backends**: `SQLiteCache`
+- **Basic Authorisation**: `BasicAuthoriser`
+- **OAuth2 Flows**: `AuthorisationCodeFlow` `AuthorisationCodePKCEFlow` `ClientCredentialsFlow`
+
+
+## Release History
+
+For change and release history, 
+check out the [documentation](https://geo-martino.github.io/aiorequestful/release-history.html).
+
+
+## Contributing
+
+For info on how to contribute to aiorequestful, 
+check out the [documentation](https://geo-martino.github.io/aiorequestful/contributing.html).
+
+
+<a id="aims"></a>
+## Motivations & Aims
+
+***Coming soon...***
+
+
+<a id="notes"></a>
+## Author notes, contributions, and reporting issues
+
+***Coming soon...***

--- a/README.template.md
+++ b/README.template.md
@@ -13,6 +13,69 @@
 [![GitHub - Deployment](https://github.com/{program_owner_user}/{program_name_lower}/actions/workflows/deploy.yml/badge.svg?event=release)](https://github.com/{program_owner_user}/{program_name_lower}/actions/workflows/deploy.yml)
 [![GitHub - Documentation](https://github.com/{program_owner_user}/{program_name_lower}/actions/workflows/docs_publish.yml/badge.svg)](https://github.com/{program_owner_user}/{program_name_lower}/actions/workflows/docs_publish.yml)
 
-### Asynchronous RESTful API requests framework for asyncio and Python
+### An Asynchronous HTTP and RESTful API requests framework for asyncio and Python
 
 ## Contents
+* [Getting Started](#quick-guides)
+* [Currently Supported](#currently-supported)
+* [Release History](#release-history)
+* [Contributing](#contributing)
+* [Motivation & Aims](#aims)
+* [Author Notes](#notes)
+
+> [!NOTE]  
+> This readme provides a brief overview of the program. 
+> [Read the docs](https://{program_owner_user}.github.io/{program_name_lower}/) for full reference documentation.
+
+
+## Installation
+Install through pip using one of the following commands:
+
+```bash
+pip install {program_name_lower}
+```
+```bash
+python -m pip install {program_name_lower}
+```
+
+There are optional dependencies that you may install for optional functionality. 
+For the current list of optional dependency groups, [read the docs](https://{program_owner_user}.github.io/{program_name_lower}/howto.install.html)
+
+
+## Getting Started
+
+These quick guides will help you get set up and going with {program_name} in just a few minutes.
+For more detailed guides, check out the [documentation](https://{program_owner_user}.github.io/{program_name_lower}/).
+
+***Coming soon...***
+
+
+## Currently Supported
+
+- **Cache Backends**: {cache_backends}
+- **Basic Authorisation**: {basic_auth}
+- **OAuth2 Flows**: {oauth2}
+
+
+## Release History
+
+For change and release history, 
+check out the [documentation](https://{program_owner_user}.github.io/{program_name_lower}/release-history.html).
+
+
+## Contributing
+
+For info on how to contribute to {program_name}, 
+check out the [documentation](https://{program_owner_user}.github.io/{program_name_lower}/contributing.html).
+
+
+<a id="aims"></a>
+## Motivations & Aims
+
+***Coming soon...***
+
+
+<a id="notes"></a>
+## Author notes, contributions, and reporting issues
+
+***Coming soon...***

--- a/aiorequestful/auth/basic.py
+++ b/aiorequestful/auth/basic.py
@@ -41,3 +41,8 @@ class BasicAuthoriser(Authoriser):
         return {
             "Authorization": f"Basic {credentials_encoded}"
         }
+
+
+BASIC_CLASSES: frozenset[type[Authoriser]] = frozenset({
+    BasicAuthoriser,
+})

--- a/aiorequestful/auth/oauth2.py
+++ b/aiorequestful/auth/oauth2.py
@@ -575,3 +575,8 @@ class AuthorisationCodePKCEFlow(AuthorisationCodeFlow):
             "redirect_uri": str(self.redirect_uri),
             "code_verifier": self.code_verifier
         }
+
+
+OAUTH2_CLASSES: frozenset[type[OAuth2Authoriser]] = frozenset({
+    ClientCredentialsFlow, AuthorisationCodeFlow, AuthorisationCodePKCEFlow,
+})

--- a/aiorequestful/cache/backend/sqlite.py
+++ b/aiorequestful/cache/backend/sqlite.py
@@ -210,7 +210,7 @@ class SQLiteTable[K: tuple[Any, ...], V: str](ResponseRepository[K, V]):
             self.settings.get_name(await self.deserialize(__value)),
             datetime.now().isoformat(),
             self.expire.isoformat(),
-            await self.serialize(__value),
+            __value,
         )
 
         await self.connection.execute(query, params)

--- a/aiorequestful/cache/session.py
+++ b/aiorequestful/cache/session.py
@@ -106,7 +106,7 @@ class CachedSession(ClientSession):
 
         if not isinstance(payload, str | bytes):
             repository = self.cache.get_repository_from_url(request.url)
-            payload = repository.serialize(payload)
+            payload = await repository.serialize(payload)
 
         return CachedResponse(request=request, payload=payload)
 

--- a/aiorequestful/request/handler.py
+++ b/aiorequestful/request/handler.py
@@ -331,7 +331,7 @@ class RequestHandler[A: Authoriser, RT: Any]:
             response=response,
             authoriser=self.authoriser,
             session=self.session,
-            payload_deserializer=self.payload_handler,
+            payload_handler=self.payload_handler,
             wait_timer=self.wait_timer,
             retry_timer=retry_timer,
         )

--- a/aiorequestful/request/handler.py
+++ b/aiorequestful/request/handler.py
@@ -32,7 +32,7 @@ _DEFAULT_RESPONSE_HANDLERS = [
 ]
 
 
-class RequestHandler[A: Authoriser, RT: Any]:
+class RequestHandler[A: Authoriser, P: Any]:
     """
     Generic HTTP request handler.
     Handles error responses, retries on failed requests, authorisation, caching etc.
@@ -125,7 +125,7 @@ class RequestHandler[A: Authoriser, RT: Any]:
             wait_timer: Timer = None,
             retry_timer: Timer = None,
             **session_kwargs
-    ) -> RequestHandler[A, RT]:
+    ) -> RequestHandler[A, P]:
         """Create a new :py:class:`RequestHandler` with an appropriate session ``connector`` given the input kwargs"""
         def connector() -> aiohttp.ClientSession:
             """Create an appropriate session ``connector`` given the input kwargs"""
@@ -233,7 +233,7 @@ class RequestHandler[A: Authoriser, RT: Any]:
 
         self.logger.log(level=level, msg=format_url_log(method=method, url=url, messages=log))
 
-    async def request(self, method: MethodInput, url: URLInput, **kwargs: Unpack[RequestKwargs]) -> RT:
+    async def request(self, method: MethodInput, url: URLInput, **kwargs: Unpack[RequestKwargs]) -> P:
         """
         Generic method for handling HTTP requests handling errors, authorisation, backoff, caching etc. as configured.
         See :py:func:`request` for more arguments.
@@ -257,7 +257,7 @@ class RequestHandler[A: Authoriser, RT: Any]:
                     continue
 
                 if response.ok:
-                    payload: RT = await self.payload_handler(response)
+                    payload: P = await self.payload_handler(response)
                     break
 
                 await self._log_response(response=response, method=method, url=url)

--- a/aiorequestful/response/exception.py
+++ b/aiorequestful/response/exception.py
@@ -20,5 +20,9 @@ class ResponseError(HTTPError):
         super().__init__(formatted)
 
 
+class PayloadHandlerError(AIORequestfulError):
+    """Error raised when handling a response's payload."""
+
+
 class StatusHandlerError(AIORequestfulError):
     """Error raised when handling a response based on its status code."""

--- a/aiorequestful/response/payload.py
+++ b/aiorequestful/response/payload.py
@@ -1,12 +1,14 @@
 """
 Resources to handle manipulation of payload data returned by responses into Python objects.
 """
+import json
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable
 from typing import Any
 
 from aiohttp import ClientResponse
 
+from aiorequestful.response.exception import PayloadHandlerError
 from aiorequestful.types import JSON
 
 
@@ -16,25 +18,68 @@ class PayloadHandler[T: Any](ABC):
     __slots__ = ()
 
     @abstractmethod
-    async def deserialize(self, response: ClientResponse) -> T:
-        """Extract payload data from the given ``response`` and serialise to the appropriate object."""
+    async def serialize(self, payload: T) -> str:
+        """Serialize the payload object to a string."""
+        return json.dumps(payload, indent=2)
+
+    @abstractmethod
+    async def deserialize(self, response: str | bytes | bytearray | ClientResponse | T) -> T:
+        """
+        Extract payload data from the given ``response`` and serialize to the appropriate object.
+
+        :param response: The response/payload to handle.
+        :raise PayloadHandlerError: When the input data is not recognised.
+        """
         raise NotImplementedError
 
-    def __call__(self, response: ClientResponse) -> Awaitable[T]:
+    def __call__(self, response: str | bytes | bytearray | ClientResponse | T) -> Awaitable[T]:
         return self.deserialize(response=response)
 
 
-class JSONPayloadHandler(PayloadHandler):
+class JSONPayloadHandler(PayloadHandler[JSON]):
+
+    __slots__ = ("indent",)
+
+    def __init__(self, indent: int = None):
+        self.indent = indent
+
+    async def serialize(self, payload: JSON) -> str:
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except (json.decoder.JSONDecodeError, TypeError):
+                raise PayloadHandlerError(f"Unrecognised input type: {payload}")
+        return json.dumps(payload, indent=self.indent)
+
+    async def deserialize(self, response: str | bytes | bytearray | ClientResponse | JSON) -> JSON:
+        match response:
+            case dict():
+                try:  # check the given payload can be converted to/from JSON format
+                    return json.loads(json.dumps(response))
+                except (json.decoder.JSONDecodeError, TypeError):
+                    raise PayloadHandlerError("Given payload is not a valid JSON object")
+            case str() | bytes() | bytearray():
+                return json.loads(response)
+            case ClientResponse():
+                return await response.json(content_type=None)
+            case _:
+                raise PayloadHandlerError(f"Unrecognised input type: {response}")
+
+
+class StringPayloadHandler(PayloadHandler[str]):
 
     __slots__ = ()
 
-    async def deserialize(self, response: ClientResponse) -> JSON:
-        return await response.json(content_type=None)
+    async def serialize(self, payload: str) -> str:
+        return str(payload)
 
-
-class StringPayloadHandler(PayloadHandler):
-
-    __slots__ = ()
-
-    async def deserialize(self, response: ClientResponse) -> str:
-        return await response.text()
+    async def deserialize(self, response: str | bytes | bytearray | ClientResponse) -> str:
+        match response:
+            case str():
+                return response
+            case bytes() | bytearray():
+                return response.decode()
+            case ClientResponse():
+                return await response.text()
+            case _:
+                return str(response)

--- a/aiorequestful/response/status.py
+++ b/aiorequestful/response/status.py
@@ -154,7 +154,7 @@ class RateLimitStatusHandler(StatusHandler):
         if retry_timer is not None and wait_seconds > retry_timer.total:  # exception if too long
             raise ResponseError(
                 "Rate limit exceeded and wait time is greater than remaining timeout "
-                f"of {retry_timer.total_remaining} seconds. Retry again at {wait_dt_str}"
+                f"of {retry_timer.total_remaining:.2f} seconds. Retry again at {wait_dt_str}"
             )
 
         if not self._wait_logged:
@@ -170,10 +170,10 @@ class RateLimitStatusHandler(StatusHandler):
         if wait_timer.increase():
             self._log(
                 response=response,
-                message=f"Increasing wait time between requests to {wait_timer.value:.2f}s"
+                message=f"Increasing wait time between requests to {float(wait_timer):.2f}s"
             )
         else:
             self._log(
                 response=response,
-                message=f"Cannot increase wait time. Already at maximum of {wait_timer.value:.2f}s"
+                message=f"Cannot increase wait time. Already at maximum of {float(wait_timer):.2f}s"
             )

--- a/docs/guides.install.rst
+++ b/docs/guides.install.rst
@@ -1,0 +1,24 @@
+.. _installation:
+
+Installation
+------------
+
+Install through pip using one of the following commands:
+
+.. code-block:: bash
+
+   pip install aiorequestful
+   # or
+   python -m pip install aiorequestful
+
+This package has various optional dependencies for optional functionality.
+Should you wish to take advantage of some or all of this functionality, install the optional dependencies as follows:
+
+.. code-block:: bash
+
+   pip install aiorequestful[all]  # installs all optional dependencies
+
+   pip install aiorequestful[sqlite]  # dependencies for working with a SQLite cache backend
+
+   # or you may install any combination of these e.g.
+   pip install aiorequestful[sqlite,test]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@
 Welcome to aiorequestful!
 =========================
 
-An Asynchronous RESTful API requests framework for asyncio and Python
----------------------------------------------------------------------
+An Asynchronous HTTP and RESTful API requests framework for asyncio and Python
+------------------------------------------------------------------------------
 
 
 Features
@@ -14,16 +14,18 @@ Features
 What's in this documentation
 ----------------------------
 
-* How to guides on getting started with AIOReqestful and other key functionality of the package
+* Guides on getting started with AIOReqestful and other key functionality of the package (*Coming soon...*)
 * Release history
 * How to get started with contributing to AIOReqestful
 * Reference documentation
 
-.. include:: howto.install.rst
+.. include:: guides.install.rst
 
 .. toctree::
    :maxdepth: 1
-   :caption: 📜 How to...
+   :caption: 📜 Guides & Getting Started
+
+   guides.install
 
 .. toctree::
    :maxdepth: 1

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -32,6 +32,19 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_
 
 
+0.5.0
+=====
+
+Changed
+-------
+* :py:class:`.Timer` now supports int and float operations.
+
+Removed
+-------
+* ``value`` property on :py:class:`.Timer` in favour of using builtin ``int`` and ``float`` calls
+  to get the timer value.
+
+
 0.4.0
 =====
 

--- a/docs/release-history.rst
+++ b/docs/release-history.rst
@@ -38,12 +38,18 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Changed
 -------
 * :py:class:`.Timer` now supports int and float operations.
+* All cache backends no longer rely on JSON based payloads and have been made generic enough
+  to support all :py:class:`.PayloadHandler` implementations.
 
 Removed
 -------
 * ``value`` property on :py:class:`.Timer` in favour of using builtin ``int`` and ``float`` calls
   to get the timer value.
 
+Documentation
+-------
+* Add standard info for installing
+* Expand and reformat index
 
 0.4.0
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "aiorequestful"
 authors = [
   { name="George Martin Marino", email="gm.engineer+aiorequestful@pm.me" },
 ]
-description = "An Asynchronous RESTful API requests framework for asyncio and Python"
+description = "An Asynchronous HTTP and RESTful API requests framework for asyncio and Python"
 readme = "README.md"
 license-files = { paths = ["LICENSE"] }
 requires-python = ">=3.12"
@@ -19,7 +19,7 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Natural Language :: English",
     "Intended Audience :: Developers",
 ]

--- a/readme.py
+++ b/readme.py
@@ -2,6 +2,9 @@
 Fills in the variable fields of the README template and generates README.md file.
 """
 from aiorequestful import PROGRAM_OWNER_USER, PROGRAM_NAME
+from aiorequestful.auth.basic import BASIC_CLASSES
+from aiorequestful.auth.oauth2 import OAUTH2_CLASSES
+from aiorequestful.cache.backend import CACHE_CLASSES
 
 SRC_FILENAME = "README.template.md"
 TRG_FILENAME = SRC_FILENAME.replace(".template", "")
@@ -15,7 +18,9 @@ def format_readme():
         "program_owner_user": PROGRAM_OWNER_USER,
     }
     format_map_code = {
-
+        "cache_backends": sorted(cls.__name__ for cls in CACHE_CLASSES),
+        "basic_auth": sorted(cls.__name__ for cls in BASIC_CLASSES),
+        "oauth2": sorted(cls.__name__ for cls in OAUTH2_CLASSES),
     }
     format_map_code = {k: "`" + "` `".join(v) + "`" for k, v in format_map_code.items()}
     format_map = format_map_standard | format_map_code

--- a/tests/cache/backend/test_sqlite.py
+++ b/tests/cache/backend/test_sqlite.py
@@ -1,6 +1,6 @@
 import contextlib
-import json
 import sqlite3
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from pathlib import Path
 from random import randrange
@@ -16,6 +16,7 @@ from yarl import URL
 from aiorequestful.cache.backend.base import ResponseRepositorySettings
 from aiorequestful.cache.backend.sqlite import SQLiteTable, SQLiteCache
 from aiorequestful.cache.response import CachedResponse
+from aiorequestful.response.payload import PayloadHandler
 from tests.cache.backend.testers import ResponseRepositoryTester, ResponseCacheTester, BaseResponseTester
 from tests.cache.backend.utils import MockPaginatedRequestSettings
 
@@ -30,7 +31,7 @@ class SQLiteTester(BaseResponseTester):
         return aiosqlite.connect(":memory:")
 
     @staticmethod
-    def generate_item(settings: ResponseRepositorySettings) -> tuple[tuple, dict[str, Any]]:
+    async def generate_item[V: Any](settings: ResponseRepositorySettings[V]) -> tuple[tuple[Any, ...], V]:
         key = ("GET", "".join(fake.random_letters(20)),)
 
         value = {
@@ -43,24 +44,30 @@ class SQLiteTester(BaseResponseTester):
         if isinstance(settings, MockPaginatedRequestSettings):
             key = (*key, randrange(0, 100), randrange(1, 50))
 
-        return key, value
+        return key, await settings.payload_handler.deserialize(value)
 
     @classmethod
-    def generate_response_from_item(
-            cls, settings: ResponseRepositorySettings, key: Any, value: Any, session: ClientSession = None
+    async def generate_response_from_item[V: Any](
+            cls, settings: ResponseRepositorySettings[V], key: Any, value: V, session: ClientSession = None
     ) -> ClientResponse:
         url = f"http://test.com/{settings.name}/{key[1]}"
-        return cls._generate_response_from_item(url=url, key=key, value=value, session=session)
+        return await cls._generate_response_from_item(
+            url=url, key=key, value=value, payload_handler=settings.payload_handler, session=session
+        )
 
     @classmethod
-    def generate_bad_response_from_item(
-            cls, settings: ResponseRepositorySettings, key: Any, value: Any, session: ClientSession = None
+    async def generate_bad_response_from_item[V: Any](
+            cls, settings: ResponseRepositorySettings[V], key: Any, value: V, session: ClientSession = None
     ) -> ClientResponse:
         url = "http://test.com"
-        return cls._generate_response_from_item(url=url, key=key, value=value, session=session)
+        return await cls._generate_response_from_item(
+            url=url, key=key, value=value, payload_handler=settings.payload_handler, session=session
+        )
 
     @staticmethod
-    def _generate_response_from_item(url: str, key: Any, value: Any, session: ClientSession = None) -> ClientResponse:
+    async def _generate_response_from_item(
+            url: str, key: Any, value: Any, payload_handler: PayloadHandler, session: ClientSession = None
+    ) -> ClientResponse:
         params = {}
         if len(key) == 4:
             params["offset"] = key[2]
@@ -72,7 +79,6 @@ class SQLiteTester(BaseResponseTester):
                 method=key[0],
                 url=URL(url),
                 params=params,
-                headers={"Content-Type": "application/json"},
                 loop=session._loop,
                 session=session
             )
@@ -81,20 +87,19 @@ class SQLiteTester(BaseResponseTester):
                 method=key[0],
                 url=URL(url),
                 params=params,
-                headers={"Content-Type": "application/json"},
             )
-        return CachedResponse(request=request, payload=json.dumps(value))
+        return CachedResponse(request=request, payload=await payload_handler.serialize(value))
 
 
 class TestSQLiteTable(SQLiteTester, ResponseRepositoryTester):
 
     @pytest.fixture
-    async def repository(
+    async def repository[V: str](
             self,
             connection: aiosqlite.Connection,
-            settings: ResponseRepositorySettings,
-            valid_items: dict,
-            invalid_items: dict
+            settings: ResponseRepositorySettings[V],
+            valid_items: dict[Iterable[Any], V],
+            invalid_items: dict[Iterable[Any], V],
     ) -> SQLiteTable:
         expire = timedelta(days=2)
 
@@ -114,14 +119,14 @@ class TestSQLiteTable(SQLiteTester, ResponseRepositoryTester):
                 f"VALUES ({",".join("?" * len(columns))});",
             ))
             parameters = [
-                (*key, datetime.now().isoformat(), repository.expire.isoformat(), repository.serialize(value))
+                (*key, datetime.now().isoformat(), repository.expire.isoformat(), await repository.serialize(value))
                 for key, value in valid_items.items()
             ]
             invalid_expire_dt = datetime.now() - expire  # expiry time in the past, response cache has expired
-            parameters.extend(
-                (*key, datetime.now().isoformat(), invalid_expire_dt.isoformat(), repository.serialize(value))
+            parameters += [
+                (*key, datetime.now().isoformat(), invalid_expire_dt.isoformat(), await repository.serialize(value))
                 for key, value in invalid_items.items()
-            )
+            ]
 
             await connection.executemany(query, parameters)
             await repository.commit()
@@ -164,46 +169,25 @@ class TestSQLiteTable(SQLiteTester, ResponseRepositoryTester):
         with pytest.raises(ValueError):
             assert await repository.count()
 
-    def test_serialize(self, repository: SQLiteTable):
-        _, value = self.generate_item(repository.settings)
-        value_serialized = repository.serialize(value)
-
-        assert isinstance(value_serialized, str)
-        assert repository.serialize(value_serialized) == value_serialized
-
-        assert repository.serialize("I am not a valid JSON") is None
-
-    # noinspection PyTypeChecker
-    def test_deserialize(self, repository: SQLiteTable):
-        _, value = self.generate_item(repository.settings)
-        value_str = json.dumps(value)
-        value_deserialized = repository.deserialize(value_str)
-
-        assert isinstance(value_deserialized, dict)
-        assert repository.deserialize(value_deserialized) == value
-
-        assert repository.deserialize(None) is None
-        assert repository.deserialize(123) is None
-
 
 class TestSQLiteCache(SQLiteTester, ResponseCacheTester):
 
     @staticmethod
-    def generate_response(settings: ResponseRepositorySettings, session: ClientSession = None) -> ClientResponse:
-        key, value = TestSQLiteTable.generate_item(settings)
-        return TestSQLiteTable.generate_response_from_item(settings, key, value, session=session)
+    async def generate_response(settings: ResponseRepositorySettings, session: ClientSession = None) -> ClientResponse:
+        key, value = await TestSQLiteTable.generate_item(settings)
+        return await TestSQLiteTable.generate_response_from_item(settings, key, value, session=session)
 
     @classmethod
     @contextlib.asynccontextmanager
-    async def generate_cache(cls) -> SQLiteCache:
+    async def generate_cache(cls, payload_handler: PayloadHandler) -> SQLiteCache:
         async with SQLiteCache(
                 cache_name="test",
                 connector=cls.generate_connection,
                 repository_getter=cls.get_repository_from_url,
         ) as cache:
             for _ in range(randrange(5, 10)):
-                settings = cls.generate_settings()
-                items = dict(TestSQLiteTable.generate_item(settings) for _ in range(randrange(3, 6)))
+                settings = cls.generate_settings(payload_handler=payload_handler)
+                items = dict([await TestSQLiteTable.generate_item(settings) for _ in range(randrange(3, 6))])
 
                 repository = await SQLiteTable(settings=settings, connection=cache.connection)
                 for k, v in items.items():

--- a/tests/cache/backend/test_sqlite.py
+++ b/tests/cache/backend/test_sqlite.py
@@ -191,7 +191,7 @@ class TestSQLiteCache(SQLiteTester, ResponseCacheTester):
 
                 repository = await SQLiteTable(settings=settings, connection=cache.connection)
                 for k, v in items.items():
-                    await repository._set_item_from_key_value_pair(k, v)
+                    await repository._set_item_from_key_value_pair(k, await repository.serialize(v))
                 cache[settings.name] = repository
 
             await cache.commit()

--- a/tests/cache/backend/testers.py
+++ b/tests/cache/backend/testers.py
@@ -221,7 +221,7 @@ class ResponseRepositoryTester(BaseResponseTester, metaclass=ABCMeta):
         assert all([not await repository.contains(key) for key, _ in items])
 
         for key, value in items:
-            await repository._set_item_from_key_value_pair(key, value)
+            await repository._set_item_from_key_value_pair(key, await repository.serialize(value))
 
         assert all([await repository.contains(key) for key, _ in items])
         for key, value in items:

--- a/tests/cache/backend/utils.py
+++ b/tests/cache/backend/utils.py
@@ -5,7 +5,7 @@ from yarl import URL
 from aiorequestful.cache.backend.base import ResponseRepositorySettings
 
 
-class MockResponseRepositorySettings(ResponseRepositorySettings):
+class MockResponseRepositorySettings[V: Any](ResponseRepositorySettings[V]):
 
     @property
     def fields(self) -> tuple[str, ...]:
@@ -17,11 +17,13 @@ class MockResponseRepositorySettings(ResponseRepositorySettings):
         return URL(url).path.split("/")[-1] or None,
 
     @staticmethod
-    def get_name(response: dict[str, Any]) -> str | None:
-        return response.get("name")
+    def get_name(payload: V) -> str | None:
+        if not isinstance(payload, dict):
+            payload = eval(payload)
+        return payload.get("name")
 
 
-class MockPaginatedRequestSettings(MockResponseRepositorySettings):
+class MockPaginatedRequestSettings[V: Any](MockResponseRepositorySettings[V]):
 
     @property
     def fields(self) -> tuple[str, ...]:

--- a/tests/cache/test_session.py
+++ b/tests/cache/test_session.py
@@ -7,16 +7,23 @@ from faker import Faker
 
 from aiorequestful.cache.backend.base import ResponseCache
 from aiorequestful.cache.session import CachedSession
+from aiorequestful.response.payload import PayloadHandler, JSONPayloadHandler, StringPayloadHandler
 from tests.cache.backend.test_sqlite import TestSQLiteCache as SQLiteCacheTester
 from tests.cache.backend.testers import ResponseCacheTester
 from tests.cache.backend.utils import MockResponseRepositorySettings
+from tests.utils import idfn
 
 fake = Faker()
 
 
 class TestCachedSession:
 
-    @pytest.fixture(scope="class", params=[SQLiteCacheTester])
+    @pytest.fixture(scope="class", params=[StringPayloadHandler(), JSONPayloadHandler(indent=2)], ids=idfn)
+    def payload_handler(self, request) -> PayloadHandler:
+        """Yields the :py:class:`PayloadHandler` to apply to the :py:class:`RequestSettings`"""
+        return request.param
+
+    @pytest.fixture(scope="class", params=[SQLiteCacheTester], ids=idfn)
     def tester(self, request) -> ResponseCacheTester:
         return request.param
 
@@ -27,9 +34,9 @@ class TestCachedSession:
 
     # noinspection PyTestUnpassedFixture
     @pytest.fixture
-    async def cache(self, tester: ResponseCacheTester) -> ResponseCache:
+    async def cache(self, tester: ResponseCacheTester, payload_handler: PayloadHandler) -> ResponseCache:
         """Yields a valid :py:class:`ResponseCache` to use throughout tests in this suite as a pytest.fixture."""
-        async with tester.generate_cache() as cache:
+        async with tester.generate_cache(payload_handler=payload_handler) as cache:
             yield cache
 
     @pytest.fixture
@@ -64,12 +71,12 @@ class TestCachedSession:
         key, value = choice([(k, v) async for k, v in repository])
         assert await repository.contains(key)
 
-        expected = tester.generate_response_from_item(repository.settings, key, value, session=session)
+        expected = await tester.generate_response_from_item(repository.settings, key, value, session=session)
         request = expected.request_info
         headers = {"Content-Type": "application/json"}
 
         async with session.request(method=request.method, url=request.url, headers=headers) as response:
-            assert await response.json() == await expected.json()
+            assert await response.text() == await expected.text()
         requests_mock.assert_not_called()
 
     async def test_request_not_cached(
@@ -81,7 +88,7 @@ class TestCachedSession:
     ):
         repository = choice(list(cache.values()))
 
-        expected = tester.generate_response(repository.settings, session=session)
+        expected = await tester.generate_response(repository.settings, session=session)
         request = expected.request_info
         headers = {"Content-Type": "application/json"}
 
@@ -91,7 +98,7 @@ class TestCachedSession:
         requests_mock.get(request.url, body=await expected.text(), repeat=True)
 
         async with session.request(method=request.method, url=request.url, headers=headers, persist=False) as response:
-            assert await response.json() == await expected.json()
+            assert await response.text() == await expected.text()
         assert len(requests_mock.requests) == 1
         assert sum(map(len, requests_mock.requests.values())) == 1
         assert not await repository.contains(key)
@@ -103,6 +110,6 @@ class TestCachedSession:
         assert await repository.contains(key)
 
         async with session.request(method=request.method, url=request.url, headers=headers) as response:
-            assert await response.json() == await expected.json()
+            assert await response.text() == await expected.text()
         assert len(requests_mock.requests) == 1
         assert sum(map(len, requests_mock.requests.values())) == 2

--- a/tests/request/test_timer.py
+++ b/tests/request/test_timer.py
@@ -30,29 +30,29 @@ class TimerTester(ABC):
     def test_increased(timer_initial: Timer):
         assert timer_initial.can_increase
 
-        initial_value = timer_initial.value
+        initial_value = float(timer_initial)
         initial_counter = timer_initial.counter
 
         assert timer_initial.increase()
-        assert timer_initial.value > initial_value
+        assert timer_initial > initial_value
         assert timer_initial.counter == initial_counter + 1
 
     @staticmethod
     def test_not_increased(timer_final: Timer):
         assert not timer_final.can_increase
 
-        initial_value = timer_final.value
+        initial_value = float(timer_final)
         assert not timer_final.increase()
-        assert timer_final.value == initial_value
+        assert timer_final == initial_value
 
     @staticmethod
     def test_basic_properties(timer_initial: Timer, timer_final: Timer, timer_infinite: Timer):
-        assert timer_initial.value == timer_initial.initial
+        assert timer_initial == timer_initial.initial
         assert timer_initial.counter == 0
         assert timer_initial.count_remaining == timer_initial.count
-        assert timer_initial.total_remaining == timer_initial.total - timer_initial.value
+        assert timer_initial.total_remaining == timer_initial.total - float(timer_initial)
 
-        assert round(timer_final.value, 2) == round(timer_final.final, 2)
+        assert round(timer_final, 2) == round(timer_final.final, 2)
         assert timer_final.count == timer_final.counter
         assert timer_final.count_remaining == 0
         assert timer_final.total_remaining == 0
@@ -72,12 +72,12 @@ class TimerTester(ABC):
     @staticmethod
     def test_copy(timer_final: Timer):
         timer_copy = copy(timer_final)
-        assert timer_copy.value == timer_final.value
+        assert timer_copy == float(timer_final)
         assert timer_copy.counter == timer_final.counter
 
         timer_deepcopy = deepcopy(timer_final)
-        assert timer_deepcopy.value < timer_final.value
-        assert timer_deepcopy.value == timer_final.initial
+        assert timer_deepcopy < float(timer_final)
+        assert timer_deepcopy == timer_final.initial
         assert timer_deepcopy.counter == 0
 
 
@@ -112,7 +112,7 @@ class TestStepCountTimer(CountTimerTester):
         timer.increase()
         timer.increase()
 
-        assert timer.value == 8
+        assert int(timer) == 8
         assert timer.counter == 2
         assert timer.count_remaining == 3
         assert timer.total_remaining == sum([11, 14, 17])
@@ -133,7 +133,7 @@ class TestGeometricCountTimer(CountTimerTester):
         timer.increase()
         timer.increase()
 
-        assert timer.value == 4
+        assert int(timer) == 4
         assert timer.counter == 2
         assert timer.count_remaining == 4
         assert timer.total_remaining == sum([8, 16, 32, 64])
@@ -154,7 +154,7 @@ class TestPowerCountTimer(CountTimerTester):
         timer.increase()
         timer.increase()
 
-        assert timer.value == 16
+        assert int(timer) == 16
         assert timer.counter == 2
         assert timer.count_remaining == 1
         assert timer.total_remaining == 256
@@ -191,7 +191,7 @@ class TestStepCeilingTimer(CeilingTimerTester):
         timer.increase()
         timer.increase()
 
-        assert timer.value == 5
+        assert int(timer) == 5
         assert timer.counter == 2
         assert timer.count_remaining == 3
         assert timer.total_remaining == sum([7, 9, 9.5])
@@ -212,7 +212,7 @@ class TestGeometricCeilingTimer(CeilingTimerTester):
         timer.increase()
         timer.increase()
 
-        assert timer.value == 4
+        assert int(timer) == 4
         assert timer.counter == 2
         assert timer.count_remaining == 4
         assert timer.total_remaining == sum([8, 16, 32, 50])
@@ -233,7 +233,7 @@ class TestPowerCeilingTimer(CeilingTimerTester):
         timer.increase()
         timer.increase()
 
-        assert timer.value == 16
+        assert int(timer) == 16
         assert timer.counter == 2
         assert timer.count_remaining == 1
         assert timer.total_remaining == 50

--- a/tests/response/test_payload.py
+++ b/tests/response/test_payload.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 from aiohttp import ClientResponse
 
+from aiorequestful.response.exception import PayloadHandlerError
 from aiorequestful.response.payload import PayloadHandler, JSONPayloadHandler, StringPayloadHandler
 from aiorequestful.types import JSON
 
@@ -20,6 +21,10 @@ class PayloadHandlerTester(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def payload_serialized(self, payload: Any) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
     def payload_encoded(self, payload: Any) -> bytes:
         raise NotImplementedError
 
@@ -30,8 +35,34 @@ class PayloadHandlerTester(ABC):
         return dummy_response
 
     @staticmethod
-    async def test_deserialize(handler: PayloadHandler, response: ClientResponse, payload: Any):
+    async def test_serialize(
+            handler: PayloadHandler,
+            response: ClientResponse,
+            payload: Any,
+            payload_serialized: str,
+            payload_encoded: bytes,
+    ):
+        assert await handler.serialize(payload) == payload_serialized
+        assert await handler.serialize(payload_serialized) == payload_serialized
+        assert await handler.serialize(payload_encoded) == payload_serialized
+        assert await handler.serialize(bytearray(payload_encoded)) == payload_serialized
+
+    @staticmethod
+    async def test_deserialize(
+            handler: PayloadHandler,
+            response: ClientResponse,
+            payload: Any,
+            payload_serialized: str,
+            payload_encoded: bytes,
+    ):
+        assert await handler.deserialize(payload) == payload
+        assert await handler.deserialize(payload_serialized) == payload
+        assert await handler.deserialize(payload_encoded) == payload
+        assert await handler.deserialize(bytearray(payload_encoded)) == payload
         assert await handler.deserialize(response) == payload
+
+        with pytest.raises(PayloadHandlerError):
+            await handler.deserialize(None)
 
 
 class TestJSONPayloadHandler(PayloadHandlerTester):
@@ -43,6 +74,10 @@ class TestJSONPayloadHandler(PayloadHandlerTester):
     @pytest.fixture
     def payload(self) -> JSON:
         return {"key": "value"}
+
+    @pytest.fixture
+    def payload_serialized(self, payload: Any) -> str:
+        return json.dumps(payload)
 
     @pytest.fixture
     def payload_encoded(self, payload: Any) -> bytes:
@@ -58,6 +93,10 @@ class TestStringPayloadHandler(PayloadHandlerTester):
     @pytest.fixture
     def payload(self) -> str:
         return "I am a payload"
+
+    @pytest.fixture
+    def payload_serialized(self, payload: Any) -> str:
+        return payload
 
     @pytest.fixture
     def payload_encoded(self, payload: Any) -> bytes:

--- a/tests/response/test_payload.py
+++ b/tests/response/test_payload.py
@@ -30,7 +30,7 @@ class PayloadHandlerTester(ABC):
         return dummy_response
 
     @staticmethod
-    async def test_serialise(handler: PayloadHandler, response: ClientResponse, payload: Any):
+    async def test_deserialize(handler: PayloadHandler, response: ClientResponse, payload: Any):
         assert await handler.deserialize(response) == payload
 
 

--- a/tests/response/test_status.py
+++ b/tests/response/test_status.py
@@ -119,11 +119,11 @@ class TestRateLimitStatusHandler(StatusHandlerTester):
 
         # no retry-after header, increases wait time
         assert not await handler(response_valid, wait_timer=wait_timer, retry_timer=retry_timer)
-        assert wait_timer.value > wait_timer.initial
-        assert wait_timer.value < wait_timer.final
-        assert retry_timer.value == retry_timer.initial
+        assert wait_timer > wait_timer.initial
+        assert wait_timer < wait_timer.final
+        assert retry_timer == retry_timer.initial
 
         # maxes wait time
         assert not await handler(response_valid, wait_timer=wait_timer, retry_timer=retry_timer)
-        assert wait_timer.value == wait_timer.final
-        assert retry_timer.value == retry_timer.initial
+        assert wait_timer == wait_timer.final
+        assert retry_timer == retry_timer.initial

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,32 @@
+from enum import Enum
 from pathlib import Path
+from typing import Any
+
+from aiorequestful.response.payload import PayloadHandler
+from aiorequestful.response.status import StatusHandler
 
 path_tests = Path(__file__).parent
 path_root = path_tests.parent
 path_resources = path_tests.joinpath("__resources")
 
 path_token = path_resources.joinpath("token").with_suffix(".json")
+
+
+# noinspection SpellCheckingInspection
+def idfn(value: Any) -> str | None:
+    """Generate test ID for Spotify API tests"""
+    if isinstance(value, Enum):
+        return value.name
+    elif isinstance(value, ParamTester):
+        return value.name
+    elif isinstance(value, PayloadHandler | StatusHandler):
+        return value.__class__.__name__
+    return value
+
+
+class ParamTester:
+    """Identifies this class as one that has a special name for logging the ID when used as a pytest param"""
+    @property
+    def name(self) -> str:
+        """The name to use when logging the ID of this param"""
+        return self.__class__.__name__


### PR DESCRIPTION
Changed
-------
* :py:class:`.Timer` now supports int and float operations.
* All cache backends no longer rely on JSON based payloads and have been made generic enough 
  to support all :py:class:`.PayloadHandler` implementations.

Removed
-------
* ``value`` property on :py:class:`.Timer` in favour of using builtin ``int`` and ``float`` calls
  to get the timer value.